### PR TITLE
Refactor vault allocations to use BigNumber validated amounts

### DIFF
--- a/routes/vaults.js
+++ b/routes/vaults.js
@@ -15,8 +15,14 @@ router.post('/invest', authenticateToken, async (req, res) => {
   const client = await pool.connect();
 
   try {
-    const totalAmount_str = amount.toString();
-    if (isNaN(parseFloat(totalAmount_str)) || parseFloat(totalAmount_str) < 100) {
+    const amountStr = amount.toString();
+    const decimalPattern = new RegExp(`^\\d+(\\.\\d{1,${tokenMap.usdc.decimals}})?$`);
+    if (!decimalPattern.test(amountStr)) {
+      return res.status(400).json({ error: 'Invalid amount format.' });
+    }
+    const totalAmount_BN = ethers.utils.parseUnits(amountStr, tokenMap.usdc.decimals);
+    const minAllocation_BN = ethers.utils.parseUnits('100', tokenMap.usdc.decimals);
+    if (totalAmount_BN.lt(minAllocation_BN)) {
       return res.status(400).json({ error: 'Minimum allocation is $100.' });
     }
 
@@ -38,10 +44,8 @@ const userQuery = `
 
     const userData = userResult.rows[0];
     const vaultData = vaultResult.rows[0];
-    
-    const userBalanceSafeString = parseFloat(userData.balance).toFixed(tokenMap.usdc.decimals);
-    const availableBalance_BN = ethers.utils.parseUnits(userBalanceSafeString, tokenMap.usdc.decimals);
-    const totalAmount_BN = ethers.utils.parseUnits(totalAmount_str, tokenMap.usdc.decimals);
+
+    const availableBalance_BN = ethers.utils.parseUnits(userData.balance.toString(), tokenMap.usdc.decimals);
 
     if (availableBalance_BN.lt(totalAmount_BN)) {
       await client.query('ROLLBACK');
@@ -49,7 +53,7 @@ const userQuery = `
     }
 
     let finalFeePercentage;
-    const baseFeePercentage = parseFloat(vaultData.fee_percentage);
+    const baseFeePercentage = Number(vaultData.fee_percentage);
 
     if (vaultData.is_fee_tier_based) {
       const discountPercentage = (userData.account_tier - 1) * 0.02; 
@@ -60,12 +64,12 @@ const userQuery = `
     }
 
     const feeMultiplier = Math.round(finalFeePercentage * 100);
-    const bonusPointsAmount_BN = totalAmount_BN.mul(feeMultiplier).div(100);
-    const tradableAmount_BN = totalAmount_BN.sub(bonusPointsAmount_BN);
+    const depositFeeAmount_BN = totalAmount_BN.mul(feeMultiplier).div(100);
+    const tradableAmount_BN = totalAmount_BN.sub(depositFeeAmount_BN);
     const newBalance_BN = availableBalance_BN.sub(totalAmount_BN);
-    const depositFeeAmount = ethers.utils.formatUnits(bonusPointsAmount_BN, 6);
+    const depositFeeAmountFormatted = ethers.utils.formatUnits(depositFeeAmount_BN, tokenMap.usdc.decimals);
 
-    await client.query('UPDATE users SET balance = $1 WHERE user_id = $2', [ethers.utils.formatUnits(newBalance_BN, 6), userId]);
+    await client.query('UPDATE users SET balance = $1 WHERE user_id = $2', [ethers.utils.formatUnits(newBalance_BN, tokenMap.usdc.decimals), userId]);
     
     const lockExpiresAt = new Date();
     lockExpiresAt.setMonth(lockExpiresAt.getMonth() + 1);
@@ -75,49 +79,52 @@ const userQuery = `
     // --- THIS IS THE CORRECTED IF/ELSE STRUCTURE ---
     if (existingPosition.rows.length > 0) {
       const currentPosition = existingPosition.rows[0];
-      
-      const currentCapitalSafeString = parseFloat(currentPosition.tradable_capital).toFixed(tokenMap.usdc.decimals);
-      const currentHWMSafeString = parseFloat(currentPosition.high_water_mark).toFixed(tokenMap.usdc.decimals);
 
-      const currentCapital_BN = ethers.utils.parseUnits(currentCapitalSafeString, 6);
-      const currentHWM_BN = ethers.utils.parseUnits(currentHWMSafeString, 6);
+      const currentCapital_BN = ethers.utils.parseUnits(currentPosition.tradable_capital.toString(), tokenMap.usdc.decimals);
+      const currentHWM_BN = ethers.utils.parseUnits(currentPosition.high_water_mark.toString(), tokenMap.usdc.decimals);
       
       const newCapital_BN = currentCapital_BN.add(tradableAmount_BN);
       const newHWM_BN = currentHWM_BN.add(tradableAmount_BN);
 
-      await client.query( 'UPDATE user_vault_positions SET tradable_capital = $1, high_water_mark = $2, lock_expires_at = $3 WHERE position_id = $4', [ ethers.utils.formatUnits(newCapital_BN, 6), ethers.utils.formatUnits(newHWM_BN, 6), lockExpiresAt, currentPosition.position_id ] );
+      await client.query( 'UPDATE user_vault_positions SET tradable_capital = $1, high_water_mark = $2, lock_expires_at = $3 WHERE position_id = $4', [ ethers.utils.formatUnits(newCapital_BN, tokenMap.usdc.decimals), ethers.utils.formatUnits(newHWM_BN, tokenMap.usdc.decimals), lockExpiresAt, currentPosition.position_id ] );
     } else {
-      await client.query( `INSERT INTO user_vault_positions (user_id, vault_id, tradable_capital, status, lock_expires_at, high_water_mark) VALUES ($1, $2, $3, 'active', $4, $5)`, [ userId, vaultId, ethers.utils.formatUnits(tradableAmount_BN, 6), lockExpiresAt, ethers.utils.formatUnits(tradableAmount_BN, 6) ] );
+      await client.query( `INSERT INTO user_vault_positions (user_id, vault_id, tradable_capital, status, lock_expires_at, high_water_mark) VALUES ($1, $2, $3, 'active', $4, $5)`, [ userId, vaultId, ethers.utils.formatUnits(tradableAmount_BN, tokenMap.usdc.decimals), lockExpiresAt, ethers.utils.formatUnits(tradableAmount_BN, tokenMap.usdc.decimals) ] );
     }
     
-    await client.query('INSERT INTO bonus_points (user_id, points_amount) VALUES ($1, $2)', [userId, depositFeeAmount]);
-    
+    await client.query('INSERT INTO bonus_points (user_id, points_amount) VALUES ($1, $2)', [userId, depositFeeAmountFormatted]);
+
     const depositFeeSplits = {
-      'DEPOSIT_FEES_LP_SEEDING': 0.01, 'DEPOSIT_FEES_LP_REWARDS': 0.15, 'DEPOSIT_FEES_TEAM': 0.25,
-      'DEPOSIT_FEES_TREASURY': 0.20, 'DEPOSIT_FEES_COMMUNITY': 0.20, 'DEPOSIT_FEES_BUYBACK': 0.10,
-      'DEPOSIT_FEES_STRATEGIC': 0.09
+      'DEPOSIT_FEES_LP_SEEDING': 1,
+      'DEPOSIT_FEES_LP_REWARDS': 15,
+      'DEPOSIT_FEES_TEAM': 25,
+      'DEPOSIT_FEES_TREASURY': 20,
+      'DEPOSIT_FEES_COMMUNITY': 20,
+      'DEPOSIT_FEES_BUYBACK': 10,
+      'DEPOSIT_FEES_STRATEGIC': 9
     };
-    await client.query(`UPDATE treasury_ledgers SET balance = balance + $1 WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'`, [depositFeeAmount]);
-    const totalDesc = `Total Deposit Fee of ${depositFeeAmount} from user ${userId}.`;
-    await client.query(`INSERT INTO treasury_transactions (to_ledger_id, amount, description) VALUES ((SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'), $1, $2)`, [depositFeeAmount, totalDesc]);
-    
+    await client.query(`UPDATE treasury_ledgers SET balance = balance + $1 WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'`, [depositFeeAmountFormatted]);
+    const totalDesc = `Total Deposit Fee of ${depositFeeAmountFormatted} from user ${userId}.`;
+    await client.query(`INSERT INTO treasury_transactions (to_ledger_id, amount, description) VALUES ((SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'), $1, $2)`, [depositFeeAmountFormatted, totalDesc]);
+
     for (const ledgerName in depositFeeSplits) {
-      const splitAmount = parseFloat(depositFeeAmount) * depositFeeSplits[ledgerName];
-      if (splitAmount > 0) {
-        await client.query(`UPDATE treasury_ledgers SET balance = balance + $1 WHERE ledger_name = $2`, [splitAmount, ledgerName]);
-        const splitDesc = `Allocated ${depositFeeSplits[ledgerName]*100}% of deposit fee to ${ledgerName}.`;
-        await client.query( `INSERT INTO treasury_transactions (from_ledger_id, to_ledger_id, amount, description) VALUES ((SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'), (SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = $1), $2, $3)`, [ledgerName, splitAmount, splitDesc] );
+      const pct = depositFeeSplits[ledgerName];
+      const splitAmount_BN = depositFeeAmount_BN.mul(pct).div(100);
+      if (!splitAmount_BN.isZero()) {
+        const splitAmountFormatted = ethers.utils.formatUnits(splitAmount_BN, tokenMap.usdc.decimals);
+        await client.query(`UPDATE treasury_ledgers SET balance = balance + $1 WHERE ledger_name = $2`, [splitAmountFormatted, ledgerName]);
+        const splitDesc = `Allocated ${pct}% of deposit fee to ${ledgerName}.`;
+        await client.query( `INSERT INTO treasury_transactions (from_ledger_id, to_ledger_id, amount, description) VALUES ((SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = 'DEPOSIT_FEES_TOTAL'), (SELECT ledger_id FROM treasury_ledgers WHERE ledger_name = $1), $2, $3)`, [ledgerName, splitAmountFormatted, splitDesc] );
       }
     }
 
-    const allocationDescription = `Allocated ${parseFloat(totalAmount_str).toFixed(2)} USDC to Vault ${vaultId}.`;
+    const allocationDescription = `Allocated ${ethers.utils.formatUnits(totalAmount_BN, tokenMap.usdc.decimals)} USDC to Vault ${vaultId}.`;
     await client.query(
       `INSERT INTO user_activity_log (user_id, activity_type, description, amount_primary, symbol_primary, status)
        VALUES ($1, 'VAULT_ALLOCATION', $2, $3, 'USDC', 'COMPLETED')`,
-      [userId, allocationDescription, totalAmount_str]
+      [userId, allocationDescription, amountStr]
     );
 
-    const xpForAmount = Math.floor(parseFloat(totalAmount_str) / 10);
+    const xpForAmount = totalAmount_BN.div(ethers.utils.parseUnits('10', tokenMap.usdc.decimals)).toNumber();
     if (xpForAmount > 0) {
       await client.query('UPDATE users SET xp = xp + $1 WHERE user_id = $2', [xpForAmount, userId]);
     }
@@ -126,7 +133,7 @@ const userQuery = `
     if (isFirstAllocation) {
       const referrerId = userData.referred_by_user_id;
       if (referrerId) {
-        const referralXP = Math.floor(parseFloat(totalAmount_str) / 10);
+        const referralXP = totalAmount_BN.div(ethers.utils.parseUnits('10', tokenMap.usdc.decimals)).toNumber();
         await client.query('UPDATE users SET xp = xp + $1 WHERE user_id = $2', [referralXP, referrerId]);
       }
     }
@@ -172,7 +179,8 @@ router.post('/withdraw', authenticateToken, async (req, res) => {
       return res.status(403).json({ error: `This position is locked for withdrawal until ${new Date(position.lock_expires_at).toLocaleDateString()}.` });
     }
 
-    const withdrawalAmount = position.tradable_capital;
+    const withdrawalAmountStr = position.tradable_capital.toString();
+    const withdrawalAmount_BN = ethers.utils.parseUnits(withdrawalAmountStr, tokenMap.usdc.decimals);
 
     // --- THIS IS THE FIX ---
     // Instead of deleting the position, we update its status.
@@ -182,11 +190,12 @@ router.post('/withdraw', authenticateToken, async (req, res) => {
     );
 
     // Create the activity log entry
-    const withdrawalDescription = `Requested withdrawal of ${parseFloat(withdrawalAmount).toFixed(2)} USDC from Vault ${vaultId}.`;
+    const withdrawalFormatted = Number(ethers.utils.formatUnits(withdrawalAmount_BN, tokenMap.usdc.decimals)).toFixed(2);
+    const withdrawalDescription = `Requested withdrawal of ${withdrawalFormatted} USDC from Vault ${vaultId}.`;
     await client.query(
       `INSERT INTO user_activity_log (user_id, activity_type, description, amount_primary, symbol_primary, status)
        VALUES ($1, 'VAULT_WITHDRAWAL_REQUEST', $2, $3, 'USDC', 'PENDING')`,
-      [userId, withdrawalDescription, withdrawalAmount]
+      [userId, withdrawalDescription, withdrawalAmountStr]
     );
 
     await client.query('COMMIT');


### PR DESCRIPTION
## Summary
- validate investment amount with regex against token decimals
- use ethers BigNumber for fee and balance arithmetic
- apply BigNumber formatting for withdrawal and ledger updates

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68972b5053b08329b02f6742ab5d3b02