### PR TITLE
Validate database env vars before pool setup

### DIFF
--- a/db.js
+++ b/db.js
@@ -5,6 +5,23 @@ const path = require('path'); // <-- Import the 'path' module
 const { Pool } = require('pg');
 require('dotenv').config();
 
+// Ensure all required environment variables for the database are present.
+const requiredEnvVars = [
+  'DB_HOST',
+  'DB_PORT',
+  'DB_USER',
+  'DB_PASSWORD',
+  'DB_DATABASE',
+];
+
+const missingVars = requiredEnvVars.filter((key) => !process.env[key]);
+
+if (missingVars.length > 0) {
+  throw new Error(
+    `Missing required database environment variables: ${missingVars.join(', ')}`
+  );
+}
+
 // --- NEW: Check if we are in a production environment ---
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -30,5 +47,10 @@ if (isProduction) {
 
 // Create the pool with the final configuration
 const pool = new Pool(dbConfig);
+
+// Log the final configuration (excluding sensitive information) for visibility.
+console.log(
+  `Database configuration loaded: ${dbConfig.user}@${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`
+);
 
 module.exports = pool;


### PR DESCRIPTION
## Summary
- check DB env vars before constructing configuration
- log db connection details at startup

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689736ebba9c8329a31a67b7aeb6c4be