### PR TITLE
Verify admin against DB lookup

### DIFF
--- a/middleware/isAdmin.js
+++ b/middleware/isAdmin.js
@@ -1,10 +1,27 @@
 // server/middleware/isAdmin.js
-const isAdmin = (req, res, next) => {
-  // This runs AFTER authenticateToken, so req.user exists
-  if (req.user && req.user.isAdmin) {
-    next(); // User is an admin, proceed
-  } else {
-    res.status(403).json({ error: 'Forbidden: Admin access required.' });
+const pool = require('../db');
+
+/**
+ * Verifies that the authenticated user still has admin privileges by querying
+ * the database rather than trusting the JWT payload.
+ */
+const isAdmin = async (req, res, next) => {
+  try {
+    if (!req.user || !req.user.id) {
+      return res.status(401).json({ error: 'Unauthorized: User information missing.' });
+    }
+
+    const { rows } = await pool.query('SELECT is_admin FROM users WHERE user_id = $1', [req.user.id]);
+
+    if (rows.length && rows[0].is_admin) {
+      return next(); // User is an admin, proceed
+    }
+
+    return res.status(403).json({ error: 'Forbidden: Admin access required.' });
+  } catch (err) {
+    console.error('Admin check failed:', err);
+    return res.status(500).json({ error: 'Server error verifying admin status.' });
   }
 };
+
 module.exports = isAdmin;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -5,7 +5,9 @@ const { ethers } = require('ethers');
 const authenticateToken = require('../middleware/authenticateToken');
 const isAdmin = require('../middleware/isAdmin');
 
-router.use(authenticateToken, isAdmin);
+// Authenticate first, then verify admin status via asynchronous DB lookup.
+router.use(authenticateToken);
+router.use(isAdmin);
 
 // --- Get Full Admin Dashboard Stats Endpoint (Ledger-Based) ---
 router.get('/dashboard-stats', async (req, res) => {


### PR DESCRIPTION
## Summary
- Query database in admin middleware using `req.user.id` to confirm admin status.
- Apply authentication and admin check sequentially in admin routes for async DB lookup.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a63b69c548329bb0173ad267384be