### PR TITLE
Validate database config env vars

### DIFF
--- a/db.js
+++ b/db.js
@@ -5,10 +5,25 @@ const path = require('path'); // <-- Import the 'path' module
 const { Pool } = require('pg');
 require('dotenv').config();
 
-// --- NEW: Check if we are in a production environment ---
+// --- Ensure all required environment variables are present ---
+const requiredEnvVars = [
+  'DB_HOST',
+  'DB_PORT',
+  'DB_USER',
+  'DB_PASSWORD',
+  'DB_DATABASE',
+];
+
+for (const key of requiredEnvVars) {
+  if (!process.env[key]) {
+    throw new Error(`FATAL ERROR: ${key} environment variable is not defined.`);
+  }
+}
+
+// --- Check if we are in a production environment ---
 const isProduction = process.env.NODE_ENV === 'production';
 
-// --- NEW: Define the base configuration ---
+// --- Define the base configuration ---
 const dbConfig = {
   host: process.env.DB_HOST,
   port: process.env.DB_PORT,
@@ -16,6 +31,10 @@ const dbConfig = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
 };
+
+// Log the configuration (excluding the password) at startup
+const { password, ...sanitizedConfig } = dbConfig;
+console.log('Database configuration loaded:', sanitizedConfig);
 
 // --- NEW: Conditionally add SSL configuration only for production ---
 if (isProduction) {

--- a/db.test.js
+++ b/db.test.js
@@ -1,0 +1,27 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const DB_ENV_VARS = {
+  DB_HOST: 'localhost',
+  DB_PORT: '5432',
+  DB_USER: 'user',
+  DB_PASSWORD: 'password',
+  DB_DATABASE: 'database',
+};
+
+test('db.js loads when all required env vars are set', { concurrency: false }, () => {
+  for (const [key, value] of Object.entries(DB_ENV_VARS)) {
+    process.env[key] = value;
+  }
+  delete require.cache[require.resolve('./db')];
+  assert.doesNotThrow(() => require('./db'));
+});
+
+test('db.js throws if a required env var is missing', { concurrency: false }, () => {
+  for (const [key, value] of Object.entries(DB_ENV_VARS)) {
+    process.env[key] = value;
+  }
+  delete process.env.DB_HOST;
+  delete require.cache[require.resolve('./db')];
+  assert.throws(() => require('./db'), /DB_HOST/);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon index.js"
+    "dev": "nodemon index.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- fail fast when DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, or DB_DATABASE are missing
- log sanitized database configuration at startup
- add tests ensuring database config requires environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897418a656883298fa260c5cd7e57d1