### PR TITLE
Use websocket block subscription for deposit scanning

### DIFF
--- a/utils/alchemyWebsocketProvider.js
+++ b/utils/alchemyWebsocketProvider.js
@@ -1,0 +1,9 @@
+const { ethers } = require('ethers');
+
+// Shared Alchemy WebSocket provider for listening to new blocks
+const network = process.env.ALCHEMY_NETWORK || 'homestead';
+const apiKey = process.env.ALCHEMY_API_KEY;
+
+const provider = new ethers.providers.AlchemyWebSocketProvider(network, apiKey);
+
+module.exports = provider;


### PR DESCRIPTION
## Summary
- add shared Alchemy WebSocket provider
- trigger deposit scans on finalized block events
- streamline deposit scanner to use minimal lookback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cd9c334188329a42de6742b959696